### PR TITLE
Enabling dispatch to work from subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following functions rely on variables set via `config()`:
 * `config('views.layout')` is used by `render()`, defaults to `layout`
 * `config('cookies.secret')` is used by `encrypt()`, `decrypt()`, `set_cookie()` and `get_cookie()`, defaults to an empty string
 * `config('cookies.flash')` is used by `flash()` for setting messages
+* `config('site.url')` is used by `site_url()` and `site_path()`
 * `config('source')` makes the specified ini contents accessible via `config()` calls
 
 ### Quick and Basic


### PR DESCRIPTION
First I want to congratulate you on this awesome small library!

I chose it as the basis for a simple markdown powered blog system, that I am about to release soon. However I needed a specific piece of functionality that wasn't possible without ugly hacks - the ability to run dispatch in a subfolder (say **http://example.com/blog/**). So I extended dispatch with two new functions and a new config setting:
- `site.url` - this config setting is optional and holds the URL of the site. It powers the below two functions.
- `site_path()` - returns the relative path from the root of the domain name. It is used in the _dispatch()_ function to strip away the unnecessary parts of the URL so the routing works properly.
- `site_url()` - returns the URL of the site (always with a trailing slash). It comes handy in templates.
