### PR TITLE
Fix typo in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,5 +5,5 @@ It creates a server process listening on port `1234`.
 
 To run the tests, do
 ```bash
-php tests.js
+php tests.php
 ```


### PR DESCRIPTION
Also the tests requires PHP 5.5 (because of curl_file_create) to run and not 5.4 as advertisted.
