### PR TITLE
Improved default base dir detection. Refactor error() for single exit

### DIFF
--- a/src/dispatch.php
+++ b/src/dispatch.php
@@ -36,14 +36,18 @@ function error($code, $callback = null) {
     (int) $code
   );
 
-  // bail early if no handler is set
-  !isset($error_callbacks[$code]) && die("{$code} {$message}");
-
   // if we got callbacks, try to invoke
-  if (isset($error_callbacks[$code]))
+  if (isset($error_callbacks[$code])) {
     call_user_func($error_callbacks[$code], $code);
+    $message = '';
+  }
+  else {
+    //set default exit message
+    $message = "{$code} {$message}";
+  }
 
-  exit;
+  exit ($message);
+
 }
 
 /**
@@ -906,6 +910,11 @@ function dispatch() {
   if ($base = config('dispatch.url')) {
     $base = rtrim(parse_url($base, PHP_URL_PATH), '/');
     $path = preg_replace('@^'.preg_quote($base).'@', '', $path);
+  }
+  else {
+    //improved base directory detection if no config specified
+    $base = rtrim(strtr(dirname($_SERVER['SCRIPT_NAME']),'\\','/' ) ,'/');		
+    $path = preg_replace('@^'.preg_quote($base).'@', '', $path);    
   }
 
   // remove router file from URI


### PR DESCRIPTION
Two simple changes. 

Refactored `error()` to have a single exit point. (I stopped short of adding an optional `$no_exit` parameter, that was just one possible idea about testability)

Improved the default base directory detection in `dispatch()`. This trick is seen in lots of frameworks and works well. It can still be explicitly overridden by the `config()`.
