### PR TITLE
Allow for latest PHP JASON_* constants.

### DIFF
--- a/src/dispatch.php
+++ b/src/dispatch.php
@@ -629,7 +629,7 @@ function json($obj, $func = null) {
   nocache();
   if (!$func) {
     header('Content-type: application/json');
-    echo json_encode($obj);
+    echo json_encode($obj, config('dispatch.json'));
   } else {
     header('Content-type: application/javascript');
     echo ";{$func}(".json_encode($obj).");";


### PR DESCRIPTION
If a config 'dispatch.json' is set, then the value is assumed to be the JSON output preference.

Setting

```
    config('dispatch.json', JSON_PRETTY_PRINT | JSON_OBJECT_AS_ARRAY) ;
```

would generate the expected formatting as output.

This is helpful to have as an option during development, and also the reason why I've let it null by default.
Offcourse leaving it null also has the added benefeit of backwards compatibility.
