### PR TITLE
Added URL setting back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ function json($obj, ...$args)
 ## Settings List
 
 * `url` specify your app's full URL (optional)
+* `views` specify your app's view directory (optional)
 
 ## Contributors
 

--- a/dispatch.php
+++ b/dispatch.php
@@ -65,8 +65,13 @@ function url($str) {
 # php template loader
 function phtml($path, $vars = []) {
   extract($vars, EXTR_SKIP);
+  $data = &$GLOBALS['noodlehaus\dispatch']['settings'];
   ob_start();
-  require $path;
+  if (isset($data['views'])){
+      require $data['views'] . $path;
+  } else {
+      require $path;
+  }
   return ob_get_clean();
 }
 


### PR DESCRIPTION
With out the URL setting it makes it quite a bit more difficult to work within a sub folder.

example with out URL setting:

``` php
// Does not work in Sub Folder
map('/', function() {
    echo "hello World!";
});

// Does work in Sub Folder
map('/subfolder/', function() {
    echo "hello World!";
});
```
