### PR TITLE
Possible bug: wrong $verb letter case in dispatch

### DIFF
--- a/dispatch.php
+++ b/dispatch.php
@@ -414,9 +414,9 @@ function dispatch() {
   # for POST requests, check for method override header or _method
   if ($verb == 'POST') {
     if (isset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
-      $verb = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
+      $verb = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
     } else {
-      $verb = isset($_POST['_method']) ? $_POST['_method'] : $verb;
+      $verb = isset($_POST['_method']) ? strtoupper($_POST['_method']) : $verb;
     }
   }
 


### PR DESCRIPTION
There can be bug when you override method by not uppercase request method name

e.g. `$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'get';` or `$_POST['_method'] = 'get';`
