### PR TITLE
Fix for routes such as /{first}/{second:.*} 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ map('GET', '/users/{id}', function ($params) {
 });
 
 # you can attach regex rules to your route symbols as well
-map('GET', '/users/{id:\d{2,5}}', function ($params) {
+map('GET', '/users/{id:\d+}', function ($params) {
   # {id} will match 12, but not 1, or 123456
 });
 

--- a/dispatch.php
+++ b/dispatch.php
@@ -444,7 +444,7 @@ function dispatch() {
     list($rexp, $call) = $temp;
 
     $rexp = trim($rexp, '/');
-    $rexp = preg_replace_callback('@\{([^:]+)(:(.+))?\}@U', $rxcb, $rexp);
+    $rexp = preg_replace_callback('@\{([^:\}]+?)(:([^\}]+))?\}@', $rxcb, $rexp);
 
     if (!preg_match('@^'.$rexp.'$@', $path, $vals)) {
       continue;

--- a/dispatch.php
+++ b/dispatch.php
@@ -444,7 +444,7 @@ function dispatch() {
     list($rexp, $call) = $temp;
 
     $rexp = trim($rexp, '/');
-    $rexp = preg_replace_callback('@\{([^:\}]+?)(:([^\}]+))?\}@', $rxcb, $rexp);
+    $rexp = preg_replace_callback('@\{([^:\}]+)(:([^\}]+))?\}@', $rxcb, $rexp);
 
     if (!preg_match('@^'.$rexp.'$@', $path, $vals)) {
       continue;

--- a/dispatch.php
+++ b/dispatch.php
@@ -444,7 +444,7 @@ function dispatch() {
     list($rexp, $call) = $temp;
 
     $rexp = trim($rexp, '/');
-    $rexp = preg_replace_callback('@\{([^:\}]+)(:([^\}]+))?\}@', $rxcb, $rexp);
+    $rexp = preg_replace_callback('@\{([^:\}]+)(:([^\}]+))?\}@U', $rxcb, $rexp);
 
     if (!preg_match('@^'.$rexp.'$@', $path, $vals)) {
       continue;


### PR DESCRIPTION
For routes with two parameters where the second one adds a regular expression, the original expression consumes too many characters, mixing both parameters. My change restricts the allowable characters to (not "}"). 