### PR TITLE
Added "U" for non-greedy matching (with test)

### DIFF
--- a/dispatch.php
+++ b/dispatch.php
@@ -444,7 +444,7 @@ function dispatch() {
     list($rexp, $call) = $temp;
 
     $rexp = trim($rexp, '/');
-    $rexp = preg_replace_callback('@<([^:]+)(:(.+))?>@', $rxcb, $rexp);
+    $rexp = preg_replace_callback('@<([^:]+)(:(.+))?>@U', $rxcb, $rexp);
 
     if (!preg_match('@^'.$rexp.'$@', $path, $vals)) {
       continue;

--- a/tests/dispatch-tests.php
+++ b/tests/dispatch-tests.php
@@ -288,6 +288,19 @@ require __DIR__.'/../dispatch.php';
   ];
   dispatch('dargs1', 'dargs2');
 
+  # two named parameters + regexp
+  map('POST', '/disp4/<value>/<rest:.*>', function ($params) {
+    assert($params['value'] === 'p123');
+    assert($params['rest'] === 'p456/p789');
+    return "disp4 matched";
+  });
+
+  # setup fake request
+  $_SERVER = [
+      'REQUEST_URI' => '/disp4/p123/p456/p789',
+      'REQUEST_METHOD' => 'POST'
+  ];
+  assert(dispatch('dargs1', 'dargs2') == 'disp4 matched');
 
   # invalid mapping setup (will also trigger 404)
   map('GET', '/disp2', 'foo');


### PR DESCRIPTION
Hi, I followed your change to v7. At one point, you already had the "U" added but removed it again in a later version. However, a route like 

    /disp4/<value>/<rest:.*>

won't match without it. To make my point, this time, I have included a test. 
Best regards,
-- Olav 