### PR TITLE
pre_replace is more then two times faster then preg_replace_callback

### DIFF
--- a/dispatch.php
+++ b/dispatch.php
@@ -430,21 +430,25 @@ function dispatch() {
   $func = null;
   $vals = null;
 
-  # replace named params (support regex formats)
-  $rxcb = function ($matches) {
-    if (isset($matches[3])) {
-      return "(?<{$matches[1]}>{$matches[3]})";
-    }
-    return "(?<{$matches[1]}>[^/]+)";
-  };
-
   # try to see if we have any matching route
   foreach ($maps as $temp) {
 
     list($rexp, $call) = $temp;
 
     $rexp = trim($rexp, '/');
-    $rexp = preg_replace_callback('@<([^:]+)(:(.+))?>@U', $rxcb, $rexp);
+
+    # replace named params (support regex formats)
+    $rexp = preg_replace(
+      [
+        '@<([^:]+)>@U', # <param> => <param>[^/]+
+        '@<([^:]+)(:(.+))?>@U', # <param:...> => (?<param>...)
+      ],
+      [
+        '<$1:[^/]+>',
+        '(?<$1>$3)',
+      ],
+      $rexp
+    );
 
     if (!preg_match('@^'.$rexp.'$@', $path, $vals)) {
       continue;


### PR DESCRIPTION
`pre_replace` is more then two times faster then `preg_replace_callback`

- `preg_replace` - **643 milliseconds**
- `preg_replace_callback` - 2498 milliseconds

```php
<?php
$patterns = [
	'route/route/<id>',
	'route/route/<id:[0-9]+>',
	'route/asdasd/<asdas>/<asdasd>/<asdasasd>',
	'route/asdasd/<asdas>/<asdasd>/<asdasasd:[0-9]>',
];


foreach (range(1, 10000) as $i) {
	foreach ($patterns as $pattern) {
		$p = preg_replace(
			[
				'@<([^:]+)>@U', # <param> => <param>[^/]+
				'@<([^:]+)(:(.+))?>@U', # <param:...> => (?<param>...)
			],
			[
				'<$1:[^/]+>',
				'(?<$1>$3)',
			],
			$pattern
		);
	}
}
```


vs ...

```php
<?php
$patterns = [
	'route/route/<id>',
	'route/route/<id:[0-9]+>',
	'route/asdasd/<asdas>/<asdasd>/<asdasasd>',
	'route/asdasd/<asdas>/<asdasd>/<asdasasd:[0-9]>',
];

$rxcb = function ($matches) {
	if (isset($matches[3])) {
		return "(?<{$matches[1]}>{$matches[3]})";
	}
	return "(?<{$matches[1]}>[^/]+)";
};


foreach (range(1, 10000) as $i) {
	foreach ($patterns as $pattern) {
		$p = preg_replace_callback('@<([^:]+)(:(.+))?>@U', $rxcb, $pattern);
	}
}
```