### PR TITLE
better PHP 7.x compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 ## dispatch
 
 - a tiny library for quick and easy PHP apps
-- requires PHP 5.6+
+- requires at least PHP 7.x
 
 Here's a sample of how you'd usually use `dispatch`.
 

--- a/dispatch.php
+++ b/dispatch.php
@@ -78,7 +78,9 @@ function serve(array $actions, $verb, $path, ...$args) {
   }
 
   if (!$match) {
-    return fn() => response('', 404, []);
+    return function () {
+      return response('', 404, []);
+    };
   }
 
   [$func, $caps] = $match;

--- a/dispatch.php
+++ b/dispatch.php
@@ -78,12 +78,10 @@ function serve(array $actions, $verb, $path, ...$args) {
   }
 
   if (!$match) {
-    return function () {
-      return response('', 404, []);
-    };
+    return response('', 404, []);
   }
 
-  [$func, $caps] = $match;
+  list($func, $caps) = $match;
 
   return empty($caps)
     ? $func(...$args)


### PR DESCRIPTION
Removed Arrow functions syntax `fn() => ...` use as it's  only available in PHP 7.4 and above. Also updated the readme to require at least PHP 7.