### PR TITLE
remove `page(...)` from features

### DIFF
--- a/dispatch.php
+++ b/dispatch.php
@@ -166,15 +166,13 @@ function render(string $body, int $code = 200, array $headers = []): void {
   !empty($body) && print $body;
 }
 
-# creates an page-rendering action
-function page(string $path, array $vars = []): callable {
-  return fn() => response(phtml($path, $vars));
-}
-
 # renders and returns the content of a template
 function phtml(string $path, array $vars = []): string {
+  if (!preg_match('@\.phtml$@', $path)) {
+    $path = "{$path}.phtml";
+  }
   ob_start();
   extract($vars, EXTR_SKIP);
-  require "{$path}.phtml";
+  require $path;
   return trim(ob_get_clean());
 }

--- a/tests/dispatch-tests.php
+++ b/tests/dispatch-tests.php
@@ -8,7 +8,6 @@ test_action();
 test_serve();
 test_stash();
 test_phtml();
-test_page();
 test_route();
 test_bind();
 test_apply();
@@ -68,12 +67,6 @@ function test_stash() {
 function test_phtml() {
   $t = phtml(__DIR__.'/test-phtml', ['name' => 'world']);
   assert($t === 'hello, world!');
-}
-
-# page()
-function test_page() {
-  $f = page(__DIR__.'/test-phtml', ['name' => 'world']);
-  assert(is_callable($f) && is_callable($f()));
 }
 
 # route()


### PR DESCRIPTION
The `page(...)` function doesn't offer flexibility when it comes to using templates that use layouts. It will be better to keep this out, and maybe later on be replaced by something more flexible.

It will be better to write your own helper that supports layout files through nested calls to `phtml(...)`, like below.

```php
# This should be in your app-specific helper library
function page(string $template, array $vars): string {

  # load the template contents with the passed in vars
  $body = phtml($template, $vars);

  # prepare meta to be injected into layout fields
  $meta = ['title' => 'My Application'];

  # load layout file with template content loaded into body + meta data
  $page = phtml(__DIR__.'/views/layout.phtml', ['body' => $body] + $meta);

  return $page;
}
```

And for the layout file:

```php
<!doctype html>
<html>
  <head><title><?= htmlentities($title) ?></title></head>
  <body><?= $body ?></body>
</html>
```

Note that the 