### PR TITLE
add `_404(...)` for setting custom 404 handlers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,9 @@ apply('^/admin/', function ($next, $params, $db) {
   return $next();
 }
 
+# Replace default 404 handler
+_404(fn() => response(phtml('not-found'), 404));
+
 # Sample route that has a named parameter value. Named parameters gets
 # passed to the handlers as the first argument as an associative array.
 # Arguments that follow the named parameters array are values passed through

--- a/dispatch.php
+++ b/dispatch.php
@@ -43,6 +43,17 @@ function route(string $method, string $path, callable ...$handlers): void {
   stash(DISPATCH_ROUTES_KEY, $routes);
 }
 
+# set a custom 404 handler for non-matching requests
+function _404(callable $handler = null): callable {
+  static $error404 = null;
+  if (func_num_args() === 0) {
+    return is_null($error404)
+      ? fn() => response('Not Found', 404)
+      : $error404;
+  }
+  return ($error404 = $handler);
+}
+
 # allows middleware mapping against paths
 function apply(...$args): void {
 
@@ -103,7 +114,7 @@ function serve(array $routes, string $reqmethod, string $reqpath, ...$args): cal
 
   # no matching route, 404
   if (empty($action)) {
-    return response('', 404, []);
+    return call_user_func(_404(), ...$args);
   }
 
   # if we have params, run them through bindings

--- a/tests/dispatch-tests.php
+++ b/tests/dispatch-tests.php
@@ -11,6 +11,7 @@ test_phtml();
 test_route();
 test_bind();
 test_apply();
+test_404();
 test_middleware();
 test_dispatch();
 
@@ -157,4 +158,19 @@ function test_dispatch() {
   ob_start();
   dispatch();
   assert(trim(ob_get_clean()) === 'hello world!');
+}
+
+# _404()
+function test_404() {
+  _404(fn() => response('not in here', 404));
+  route('GET', '/bar', function () {
+    return response('bar!');
+  });
+  $_SERVER = [
+    'REQUEST_METHOD' => 'GET',
+    'REQUEST_URI' => '/fizz'
+  ];
+  ob_start();
+  dispatch();
+  assert(trim(ob_get_clean()) === 'not in here');
 }


### PR DESCRIPTION
The `_404(...)` function lets you set a handler function whenever no matching route is found for the request. Note that even for 404s, all middleware are still executed. Calling the function without a callable argument will return the current/default 404 handler function.

```php
# replace the default handler
_404(fn() => response('Oops! Content not found!', 404));

# more show template contents for 404s
_404(fn() => response(phtml('not-found.phtml'), 404));
```