### PR TITLE
allow forwarding of data via middleware's call to `$next(...)`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ bind('user', function (string $username, $db): array {
 apply(function (callable $next, array $params, $db) {
   if (isDeviceRestricted($_SERVER)) {
     # returning a response here breaks the middleware chain
-    return resource('Forbidden', 403);
+    return response('Forbidden', 403);
   }
   # we move on to the next middleware
   return $next();
@@ -67,7 +67,7 @@ apply('^/admin/', function ($next, $params, $db) {
   # note that because of the named parameter binding above, the
   # value of $params['user'] is already the loaded user profile
   if (!isAdmin($params['user'])) {
-    return resource('Forbidden', 403);
+    return response('Forbidden', 403);
   }
   return $next();
 }


### PR DESCRIPTION
This change allows variables to be forwarded from within a middleware to the next by passing them as a parameter to the call to `$next(...)`. The data passed this way gets appended to the end of the arguments list that ultimately gets received by the handler as well.

```php
# load and forward the user data down the middleware chain
apply(function ($next, $db) {
  $user = loadUserProfile($db);
  return $next($user ?? null);
});

# we receive forwarded middleware data as args ($db from dispatch, $user from middleware)
route('GET', '/profile', function ($db, $user) {
  return response(json_encode($user));
});

$db = createDbConnection();
dispatch($db);
```

Note that the data is received in the same order in which the middleware functions were executed.