### PR TITLE
Add mechanism for rewriting URL path as a standalone PHP file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -137,6 +137,29 @@ mappings will have already updated the values inside the `$params` array that's
 forwarded down the execution chain.
 
 
+## URL Rewriting as a standalone PHP file
+
+If you are running Dispatch as a stanalone PHP file, either on the root path or not (eg: `path/to/search.php`), this can cause errors with path matching.
+
+You can use the `DISPATCH_PATH_PREFIX` global to mimic URL rewriting used in other libraries;
+
+```php
+<?php
+// file: path/to/search.php
+
+// NOTE: this must be defined before calling the dispatch.php file
+define('DISPATCH_PATH_PREFIX', '/path/to/search.php');
+
+require __DIR__ . '/dispatch.php';
+
+route('GET', '/testing', function() {
+  echo "test page on subpath " . $_SERVER['REQUEST_URI'];
+});
+
+dispatch();
+```
+
+
 ## license
 
 MIT

--- a/dispatch.php
+++ b/dispatch.php
@@ -7,6 +7,10 @@ define('DISPATCH_ROUTES_KEY', '__dispatch_routes__');
 define('DISPATCH_MIDDLEWARE_KEY', '__dispatch_middleware__');
 define('DISPATCH_BINDINGS_KEY', '__dispatch_bindings__');
 
+if (!defined('DISPATCH_PATH_PREFIX')) {
+  define('DISPATCH_PATH_PREFIX', '');
+}
+
 # sets or gets a value in a request-scope storage
 function stash(string $key, mixed $value = null): mixed {
   static $store = [];
@@ -22,6 +26,8 @@ function dispatch(...$args): void {
 
   $method = strtoupper($_SERVER['REQUEST_METHOD']);
   $path = '/'.trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+
+  $path = substr($path, strlen(DISPATCH_PATH_PREFIX));
 
   # post method override
   if ($method === 'POST') {


### PR DESCRIPTION
Needed a way to run Dispatch in a subdirectory without URL rewriting via the proxy/server.

Provided a sample use case in the `README.markdown` file